### PR TITLE
Fix for Jupyter slideshow mode

### DIFF
--- a/js/src/core/lib/screenshot.js
+++ b/js/src/core/lib/screenshot.js
@@ -40,8 +40,7 @@ function screenshotButton(container, K3D) {
         'cursor: pointer',
         'width: 24px',
         'height: 24px',
-        'padding: 2px',
-        'vertical-align: top;'
+        'padding: 2px'
     ].join(';');
 
     element.style.cssText = 'margin: 0 3px';


### PR DESCRIPTION
This attribute caused a bad alignment of the screenshot button in Jupyter slideshow mode. KK