### PR TITLE
include setupbase in MANIFEST so source archive is installable

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include k3d/static *
 include k3d/k3d_extension.json
+include setupbase.py


### PR DESCRIPTION
The source archive on PyPi is not installable due to the missing `setupbase.py`, this PR fixes that