### PR TITLE
Fix Sphinx warnings: make copyright and author strings Unicode in con…

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,8 +64,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'K3D-jupyter'
-copyright = '2018, Marcin Kostur, Artur Trzęsiok, Filip Kaśkosz'
-author = 'Marcin Kostur, Artur Trzęsiok, Filip Kaśkosz'
+copyright = u'2018, Marcin Kostur, Artur Trzęsiok, Filip Kaśkosz'
+author = u'Marcin Kostur, Artur Trzęsiok, Filip Kaśkosz'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
…f.py

This should fix the warnings visible here: https://readthedocs.org/projects/k3d-jupyter/builds/8062905/

Running Sphinx v1.8.1
WARNING: the config value 'epub_copyright' is set to a string with non-ASCII characters; this can lead to Unicode errors occurring. Please use Unicode strings, e.g. u'Content'.
WARNING: the config value 'copyright' is set to a string with non-ASCII characters; this can lead to Unicode errors occurring. Please use Unicode strings, e.g. u'Content'.
WARNING: the config value 'author' is set to a string with non-ASCII characters; this can lead to Unicode errors occurring. Please use Unicode strings, e.g. u'Content'.
WARNING: the config value 'epub_author' is set to a string with non-ASCII characters; this can lead to Unicode errors occurring. Please use Unicode strings, e.g. u'Content'.
WARNING: the config value 'epub_publisher' is set to a string with non-ASCII characters; this can lead to Unicode errors occurring. Please use Unicode strings, e.g. u'Content'.