### PR TITLE
PEP 396: import __version__

### DIFF
--- a/k3d/__init__.py
+++ b/k3d/__init__.py
@@ -1,4 +1,4 @@
-from ._version import version_info
+from ._version import version_info, __version__
 
 from .colormaps import paraview_color_maps
 from .colormaps import basic_color_maps


### PR DESCRIPTION
It's [PEP standard 396](https://www.python.org/dev/peps/pep-0396/) to make `__version__` available at the top level of a package. Also [PEP 8](https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names)

Currently:

```py
>>> import k3d
>>> k3d.__version__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'k3d' has no attribute '__version__'
```

