### PR TITLE
follow migration guide for ipywidgets 7 -> 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^4.1.0",
+    "@jupyter-widgets/base": "^4.1.0 || ^5 || ^6",
     "fflate": "^0.7.3",
     "file-saver": "^2.0.5",
     "katex": "^0.15.6",

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup_args = dict(
     packages=setuptools.find_packages(),
     install_requires=[
         "traittypes",
-        "ipywidgets",
+        "ipywidgets>=7,<9",
         "traitlets",
         "numpy",
         "msgpack"


### PR DESCRIPTION
This is mostly updating dependency pins.

The [guide](https://ipywidgets.readthedocs.io/en/stable/migration_guides.html#updating-the-webpack-publicpath-configuration) also mentions updating the webpack config, but that is out of my range.
