### PR TITLE
chore: skip if package already built

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ ensured-targets = [
     "k3d/labextension/package.json",
     "js/src/index.js",
 ]
+skip-if-exists = ["k3d/labextension/package.json"]
 dependencies = [
     "hatch-jupyter-builder>=0.6.2",
 ]


### PR DESCRIPTION
`hatch-jupyter-builder` always runs by default, unless we set `skip-if-exists`