### PR TITLE
Supporting user generated normals for Standard Mesh object

### DIFF
--- a/js/src/k3d.js
+++ b/js/src/k3d.js
@@ -83,6 +83,7 @@ class ObjectModel extends widgets.WidgetModel {
         triangles_attribute: serialize,
         vertices: serialize,
         indices: serialize,
+        normals: serialize,
         colors: serialize,
         origins: serialize,
         vectors: serialize,

--- a/js/src/providers/threejs/objects/MeshStandard.js
+++ b/js/src/providers/threejs/objects/MeshStandard.js
@@ -32,6 +32,7 @@ module.exports = {
             const colorMap = (config.color_map && config.color_map.data) || null;
             const attribute = (config.attribute && config.attribute.data) || null;
             const triangleAttribute = (config.triangles_attribute && config.triangles_attribute.data) || null;
+            const normals = (config.normals && config.normals.data) || null;
             const vertices = (config.vertices && config.vertices.data) || null;
             const indices = (config.indices && config.indices.data) || null;
             const uvs = (config.uvs && config.uvs.data) || null;
@@ -40,10 +41,16 @@ module.exports = {
             let object;
             let preparedtriangleAttribute;
 
+            const has_normals = (normals !== null && normals.length > 0);
+
             modelMatrix.set.apply(modelMatrix, config.model_matrix.data);
 
             geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3));
             geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+
+            if (config.flat_shading === false && has_normals) {
+                geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3)); 
+            }
 
             const material = new MaterialConstructor({
                 color: config.color,
@@ -59,7 +66,7 @@ module.exports = {
             });
 
             function finish() {
-                if (config.flat_shading === false) {
+                if (config.flat_shading === false && !has_normals) {
                     geometry.computeVertexNormals();
                 }
 

--- a/k3d/factory.py
+++ b/k3d/factory.py
@@ -351,6 +351,7 @@ def marching_cubes(
 def mesh(
         vertices,
         indices,
+        normals=[],
         color=_default_color,
         colors=[],
         attribute=[],
@@ -382,6 +383,9 @@ def mesh(
         Array of triangle vertices, `float` (x, y, z) coordinate triplets.
     indices : array_like
         Array of vertex indices. `int` triplets of indices from vertices array.
+    normals: array_like, optional
+        Array of vertex normals: float (x, y, z) coordinate triples. Normals are used when flat_shading is false.
+        If the normals are not specified here, normals will be automatically computed.
     color : int, optional
         Hex color of the vertices when `colors` is empty, by default _default_color.
     colors : list, optional
@@ -471,6 +475,7 @@ def mesh(
         Mesh(
             vertices=vertices,
             indices=indices,
+            normals=normals,
             color=color,
             colors=colors,
             attribute=attribute,

--- a/k3d/objects.py
+++ b/k3d/objects.py
@@ -496,6 +496,9 @@ class Mesh(DrawableWithCallback):
             Array of triangle vertices: float (x, y, z) coordinate triplets.
         indices: `array_like`.
             Array of vertex indices: int triplets of indices from vertices array.
+        normals: `array_like`.
+            Array of vertex normals: float (x, y, z) coordinate triples. Normals are used when flat_shading is false.
+            If the normals are not specified here, normals will be automatically computed.
         color: `int`.
             Packed RGB color of the mesh (0xff0000 is red, 0xff is blue) when not using color maps.
         colors: `array_like`.
@@ -537,6 +540,9 @@ class Mesh(DrawableWithCallback):
     )
     indices = TimeSeries(Array(dtype=np.uint32)).tag(
         sync=True, **array_serialization_wrap("indices")
+    )
+    normals = TimeSeries(Array(dtype=np.float32)).tag(
+        sync=True, **array_serialization_wrap("normals")
     )
     color = TimeSeries(Int(min=0, max=0xFFFFFF)).tag(sync=True)
     colors = TimeSeries(Array(dtype=np.uint32)).tag(


### PR DESCRIPTION
# Supporting Normals input for Mesh

## Problem
Users might some times want to use custom normals with their 3d Mesh as opposed to the ones computed by the provider (in this case three.js). This is currently not supported in k3d.

## Solution
Introduce a new parameter to the Mesh object and support custom normals in MeshStandard.js. 

## Proof of Life
Before:
![Screenshot from 2023-03-08 21-50-46](https://user-images.githubusercontent.com/7607937/223932995-d70c7139-bb49-4cfd-9175-ecc4fe095605.png)

Notice that flat_shading is False, meaning computeNormals is used.

After:
![Screenshot from 2023-03-08 21-50-22](https://user-images.githubusercontent.com/7607937/223933021-c5ce361a-dc26-413c-b6fa-cf3c28882642.png)

Notice that user generated normals are passed to the mesh factory.

## Questions
At it's current state this is a relatively safe change to merge. That said here are some pending questions
1. Do we need a test case for this? It's not a drastic change, so I'm not sure if a test is needed. But community can vote on this.
2. It is unclear if MeshVolume should also be getting this normals update. Thoughts?
3. How to update the document to indicate this new change?