### PR TITLE
Use ResizeObserver on DOM element 

### DIFF
--- a/js/src/core/Core.js
+++ b/js/src/core/Core.js
@@ -1221,7 +1221,7 @@ function K3D(provider, targetDOMNode, parameters) {
         }
 
         listeners = {};
-        currentWindow.removeEventListener('resize', this.resizeHelper);
+        this.resizeObserver.disconnect();
         world.renderer.removeContextLossListener();
         world.renderer.forceContextLoss();
     };
@@ -1235,7 +1235,10 @@ function K3D(provider, targetDOMNode, parameters) {
     this.Provider.Initializers.Scene.call(world, this);
     this.Provider.Initializers.Manipulate.call(world, this);
 
-    currentWindow.addEventListener('resize', this.resizeHelper, false);
+    this.resizeObserver = new ResizeObserver(entries => {
+        this.resizeHelper();
+    });
+    this.resizeObserver.observe(targetDOMNode);
 
     // load toolbars
     guiContainer = currentWindow.document.createElement('div');


### PR DESCRIPTION
Currently, K3D listens for browser window resize events. This causes issues when the DOM element into which K3D renders is resized for some reason while the browser window does not change its size. In particular, this often seems to be the case when when a K3D plot is placed into an ipywidgets container. By using a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) on the `targetDOMNode`, this issue is avoided.

For example, on k3d-2.15.3 with

```
ipykernel==6.23.1
ipython==8.14.0
ipywidgets==8.0.6
jupyter-events==0.6.3
jupyter-lsp==2.2.0
jupyter_client==8.2.0
jupyter_core==5.3.0
jupyter_server==2.6.0
jupyter_server_terminals==0.4.4
jupyterlab==4.0.1
jupyterlab-pygments==0.2.2
jupyterlab-widgets==3.0.7
jupyterlab_server==2.22.1
```

I see the following issue:

![k3d_mwe](https://github.com/K3D-tools/K3D-jupyter/assets/2648288/453c7d9f-2472-446b-805a-2599b906ab99)

With the proposed changes, the plot is correctly displayed.