### PR TITLE
'--disable-crash-reporter' in Chrome options

### DIFF
--- a/k3d/headless.py
+++ b/k3d/headless.py
@@ -142,6 +142,7 @@ def get_headless_driver(no_headless=False):
     options = webdriver.ChromeOptions()
 
     options.add_argument("--no-sandbox")
+    options.add_argument("--disable-crash-reporter")
 
     if not no_headless:
         options.add_argument("--headless")


### PR DESCRIPTION
Adding this option here prevents Chrome from trying to setup /tmp/Crashpad directory, which is problematic in shared environments, where file rights do not allow for that