### PR TITLE
chore: Add missing doc build dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,6 @@ traitlets
 numpy
 jupyter_sphinx
 pydata_sphinx_theme
+pyvista
+SimpleITK
 sphinx-copybutton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,20 @@ examples = [
     "vtk"
 ]
 
+[dependency-groups]
+docs = [
+    "six",
+    "ipywidgets>=7.0.1",
+    "traittypes",
+    "traitlets",
+    "numpy",
+    "jupyter_sphinx",
+    "pydata_sphinx_theme",
+    "pyvista",
+    "SimpleITK",
+    "sphinx-copybutton",
+]
+
 [project.license]
 file = "LICENSE.txt"
 


### PR DESCRIPTION
pyvista and SimpleITK are required dependencies to build the docs, but are not listed in `docs/requirements.txt`. This commit adds those dependencies to `docs/requirements.txt`.

Additionally, I have added a `docs` dependency group to the `pyproject.toml`, so you can install doc build dependencies with `pip install . --group docs` with pip >= 25.1, or equivalently `uv sync --group docs`.

Closes #476