### PR TITLE
Point dependabot at devel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+# target-branch on every entry: without it dependabot opens against the repository's default
+# branch, which is main, and every bump has to be retargeted by hand before it can go through
+# the usual devel -> main route.
+updates:
+  # the published JS package
+  - package-ecosystem: npm
+    directory: /js
+    target-branch: devel
+    schedule:
+      interval: weekly
+
+  # the root package.json, which orchestrates the build
+  - package-ecosystem: npm
+    directory: /
+    target-branch: devel
+    schedule:
+      interval: weekly


### PR DESCRIPTION
#516 and #518 both opened against `main` and had to be retargeted by hand. That is the default behaviour: with no `.github/dependabot.yml`, dependabot targets the repository's default branch, so every future bump would have needed the same treatment before it could take the usual `devel -> main` route.

Two npm entries, because dependabot sees two manifests — `js/package.json`, which is what gets published, and the root one that orchestrates the build. Both were already being watched; this only redirects them.

**No pip entry.** Dependabot is not watching the Python dependencies today, so adding one here would start a stream of pull requests for numpy, traitlets and the rest rather than restore existing behaviour. It is one block away if that is wanted.

### One thing worth a separate decision

`js/yarn.lock` is tracked alongside `js/package-lock.json`, while the root `yarn.lock` is in `.gitignore` — so the repo's own convention says yarn is not in use, and the build runs npm. That second lockfile is half of what #518 touched, and it will keep producing advisories for a dependency tree nobody installs. Removing it would cut the noise, but that is a separate change and not one to fold in here.