### PR TITLE
Take fast-uri to 3.1.7, clearing four advisories in the build toolchain

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -2319,7 +2319,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Clears the `fast-uri` advisory that dependabot raised twice overnight, taken through `devel` so the branches stay in step.

`npm audit` reported one high-severity finding against `fast-uri` 3.0.0–3.1.5, covering four advisories:

| | |
|---|---|
| [GHSA-5jgf-p345-68v8](https://github.com/advisories/GHSA-5jgf-p345-68v8) | host confusion via skipped IDN canonicalization on scheme-relative references |
| [GHSA-jqff-g426-hqxp](https://github.com/advisories/GHSA-jqff-g426-hqxp) | host confusion via percent-encoded scheme normalization |
| [GHSA-f65p-4m7j-42xc](https://github.com/advisories/GHSA-f65p-4m7j-42xc) | SSRF via malformed IPv6 normalization |
| [GHSA-fph4-wmhf-6fwf](https://github.com/advisories/GHSA-fph4-wmhf-6fwf) | SSRF via repeated hostname percent-decoding |

It is a transitive dependency of `ajv` 8, which webpack's `schema-utils` pulls in for option validation, so this is a lockfile refresh — `ajv` asks for `^3.0.1` and 3.1.7 satisfies it with no manifest change. Three lines.

## Scope of the exposure

Worth stating rather than letting "high severity" speak for itself: `fast-uri` never reaches a published artefact. It appears zero times in `js/dist/standalone.js` and zero times in `k3d/static/widget.mjs`, so this is build-time only — nothing shipped to users was affected.

## Supersedes #529 and #530

Both were dependabot finding the same advisory, and neither is merged here.

**#529** patched the root `package-lock.json` and had already gone stale by the time it was reviewed: that file no longer contains `fast-uri`, because #528 emptied the root manifest's dependency list. It shows as conflicting for exactly that reason.

**#530** is byte-for-byte identical to this commit, down to the `integrity` hash, and was opened three minutes after #528 merged — dependabot rescanned `main`, saw the root lockfile was empty, and found the package where it actually lives. It is taken through `devel` rather than merged straight into `main` so the two branches do not drift, which is the pattern this project follows.

Both arrived against `main` rather than `devel`, which is documented behaviour: dependabot security updates target the default branch regardless of `target-branch`, and they ignore the grouping added in #528. So this is the grouping working as intended, not around it.

## Verification

Run locally in the project's Docker image:

- `npm audit` in `js/` — back to **0 vulnerabilities**
- `npm ci` and `webpack --mode=production` — green
- the bundles come out **byte-identical** before and after the bump (`standalone.js` `9ec02b80…`, `widget.mjs` `3c8864b9…`), which is why this does not need a suite run to justify it
- `python -m ruff check .` — passed
- `npx grunt codeStyle` — exit 0
